### PR TITLE
docs: Improve readability of UserStyle metadata example

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ yarn format:check  # Check formatting without writing
 This is a collection of UserStyle CSS files (`.user.css`) for browser extensions like Stylus. Each file targets a specific website using `@-moz-document domain("...")` blocks.
 
 All styles live in `css/` and follow the UserStyle metadata format:
+
 ```css
 /* ==UserStyle==
 @name           site-name


### PR DESCRIPTION
This pull request makes a minor documentation improvement by adding a code block to clarify the UserStyle metadata format in the `CLAUDE.md` file.